### PR TITLE
Fix parameter name conflicts with built-in functions

### DIFF
--- a/dataset/preprocess.py
+++ b/dataset/preprocess.py
@@ -59,7 +59,7 @@ def welch_spectrum(x, fs, window='hann', nperseg=None, noverlap=None, nfft=None,
     
     # Use appropriate nfft
     if nfft is None:
-        nfft = max(256, 2 ** int(np.log2(len(x))))
+        nfft = np.maximun(256, 2 ** int(np.log2(len(x))))
     
     try:
         f, Pxx = welch(x, fs, window=window, nperseg=nperseg, noverlap=noverlap, nfft=nfft)


### PR DESCRIPTION
## Fix parameter name conflicts with built-in functions in preprocess.py

### 🐛 Problem
The `welch_spectrum` function uses parameter names `min` and `max` which shadow Python's built-in functions, causing `TypeError: 'int' object is not callable` when trying to use `max()` inside the functions.

### 🔧 Solution
- Renamed function from `max` to `np.maximun`, as did in the `get_hr` function in the same file.