### PR TITLE
Fix parameter name conflicts with built-in functions in preprocess.py

### DIFF
--- a/dataset/preprocess.py
+++ b/dataset/preprocess.py
@@ -59,7 +59,7 @@ def welch_spectrum(x, fs, window='hann', nperseg=None, noverlap=None, nfft=None,
     
     # Use appropriate nfft
     if nfft is None:
-        nfft = np.maximun(256, 2 ** int(np.log2(len(x))))
+        nfft = np.maximum(256, 2 ** int(np.log2(len(x))))
     
     try:
         f, Pxx = welch(x, fs, window=window, nperseg=nperseg, noverlap=noverlap, nfft=nfft)


### PR DESCRIPTION
## Fixed Typing Error

### 🐛 Problem
Sorry that I mistyped 'maximum' to 'maximun' in the last pr. Fixed this time.

### 🔧 Solution
- Renamed function from `np.maximum` to `np.maximum`, as did in the `get_hr` function in the same file.